### PR TITLE
Rename 'authorization' header to 'x-access-token'

### DIFF
--- a/example/lib/helpers.js
+++ b/example/lib/helpers.js
@@ -66,7 +66,7 @@ function authSuccess(req, res) {
 
   res.writeHead(200, {
     'Content-Type': 'text/html',
-    'authorization': token
+    'x-access-token': token
   });
   return res.end(restricted);
 }
@@ -108,13 +108,13 @@ function verify(token) {
 function privado(res, token) {
   res.writeHead(200, {
     'Content-Type': 'text/html',
-    'authorization': token
+    'x-access-token': token
   });
   return res.end(restricted);
 }
 
 function validate(req, res, callback) {
-  var token = req.headers.authorization;
+  var token = req.headers['x-access-token'];
   var decoded = verify(token);
   if(!decoded || !decoded.auth) {
     authFail(res);
@@ -162,7 +162,7 @@ function done(res) {
 
 function logout(req, res, callback) {
   // invalidate the token
-  var token = req.headers.authorization;
+  var token = req.headers['x-access-token'];
   // console.log(' >>> ', token)
   var decoded = verify(token);
   if(decoded) { // otherwise someone can force the server to crash by sending a bad token!

--- a/example/test/functional.js
+++ b/example/test/functional.js
@@ -58,7 +58,7 @@ test("handler", function (t) {
   var postdata = { username: 'masterbuilder', password: 'itsnosecret' }
   mock.req.emit('data', qs.stringify(postdata));
   mock.req.emit('end');
-  token = mock.res.headers.authorization;
+  token = mock.res.headers['x-access-token'];
   // console.log(lib.verify(token));
   t.equal(mock.res.status, 200, "Authenticated");
   t.end();
@@ -68,12 +68,12 @@ test("validation fail (bad-but-valid token)", function (t) {
   var token = jwt.sign({
     auth:  'invalid',
     agent: mock.req.headers['user-agent'],
-    exp:   Math.floor(new Date().getTime()/1000) + 7*24*60*60; // in seconds!
+    exp:   Math.floor(new Date().getTime()/1000) + 7*24*60*60 // in seconds!
   }, secret);
 
   // console.log(lib.verify(token));
 
-  mock.req.headers.authorization = token; // we got this above
+  mock.req.headers['x-access-token'] = token; // we got this above
   lib.validate(mock.req, mock.res, function(res){
     // console.log(res);
     t.equal(res.status, 401, "should NOT validate using BAD token");
@@ -82,7 +82,7 @@ test("validation fail (bad-but-valid token)", function (t) {
 });
 
 test("validation fail (invalid token)", function (t) {
-  mock.req.headers.authorization = 'malformed token'; // we got this above
+  mock.req.headers['x-access-token'] = 'malformed token'; // we got this above
   lib.validate(mock.req, mock.res, function(res){
     t.equal(res.status, 401, "should NOT validate using INVALID token");
     t.end();
@@ -91,7 +91,7 @@ test("validation fail (invalid token)", function (t) {
 
 
 test("validate", function (t) {
-  mock.req.headers.authorization = token; // we got this above
+  mock.req.headers['x-access-token'] = token; // we got this above
   // console.log(lib.verify(token));
   // console.log(token);
   lib.validate(mock.req, mock.res, function(res){
@@ -111,7 +111,7 @@ test("logout", function (t) {
 
 test("no access after logout", function (t){
   // confirm cannot access restricted content anymore:
-  mock.req.headers.authorization = token; // we got this above
+  mock.req.headers['x-access-token'] = token; // we got this above
   lib.validate(mock.req, mock.res, function(res){
     // console.log(res);
     t.equal(res.status, 401, "No longer has access to private content!");
@@ -121,7 +121,7 @@ test("no access after logout", function (t){
 
 
 test("malicious logout", function (t) {
-  mock.req.headers.authorization = 'malformed token'; // we got this above
+  mock.req.headers['x-access-token'] = 'malformed token'; // we got this above
   lib.logout(mock.req, mock.res, function(res){
     // console.log(res.status);
     t.equal(res.status, 401, "Logged out");
@@ -149,7 +149,7 @@ test("validation fail (expired token)", { timeout: 1500 }, function (t) {
     expires: Math.floor(new Date().getTime()/1000) + 1 // 1 second in the future, value in seconds
   });
 
-  mock.req.headers.authorization = token;
+  mock.req.headers['x-access-token'] = token;
 
   setTimeout(function() {
     lib.validate(mock.req, mock.res, function(res){

--- a/example/test/integration.js
+++ b/example/test/integration.js
@@ -61,7 +61,7 @@ setTimeout(function() { // only run tests once child_process has started
 
     var options = {
       headers: {
-        'authorization': 'invalid',
+        'x-access-token': 'invalid',
         'user-agent': 'Mozilla/5.0'
       },
       uri: host+port+"/private",
@@ -99,7 +99,7 @@ setTimeout(function() { // only run tests once child_process has started
     }
 
     request.post(options ,function (err, res, body) {
-      token = res.headers.authorization; // save the token for later
+      token = res.headers['x-access-token']; // save the token for later
       t.equal(res.statusCode, 200, "Authenticated");
       t.end();
     });
@@ -109,7 +109,7 @@ setTimeout(function() { // only run tests once child_process has started
 
     var options = {
       headers: {
-        'authorization': token,
+        'x-access-token': token,
         'user-agent': 'Mozilla/5.0'
       },
       uri: host+port+"/private",
@@ -126,7 +126,7 @@ setTimeout(function() { // only run tests once child_process has started
   test("Log out "+host+port+"/logout", function (t) {
     var options = {
       headers: {
-        'authorization': token,
+        'x-access-token': token,
         'user-agent': 'Mozilla/5.0'
       },
       uri: host+port+"/logout",
@@ -143,7 +143,7 @@ setTimeout(function() { // only run tests once child_process has started
   test("Attempt access using expired token (after logout)", function (t) {
     var options = {
       headers: {
-        'authorization': token,
+        'x-access-token': token,
         'user-agent': 'Mozilla/5.0'
       },
       uri: host+port+"/private",


### PR DESCRIPTION
The readme refers to `x-access-token` as the header that'll be used to pass the token around in, but the code didn't. Now is do.

![](https://33.media.tumblr.com/avatar_ebd6093ff85a_512.png)
