### PR TITLE
fix issue with path.resolve() where result was malformed

### DIFF
--- a/example/lib/helpers.js
+++ b/example/lib/helpers.js
@@ -9,7 +9,7 @@ var jwt  = require('jsonwebtoken');
 var secret = process.env.JWT_SECRET || "CHANGE_THIS_TO_SOMETHING_RANDOM"; // super secret
 
 function loadView(view) {
-  var filepath = path.resolve(__dirname + '/../views/' + view + '.html');
+  var filepath = path.resolve(__dirname, '../views/', view + '.html');
   return fs.readFileSync(filepath).toString();
 }
 


### PR DESCRIPTION
Just using concatenation was not providing the expected result. 

```
Error: ENOENT: no such file or directory, open '/<path>/<to>/<repo>/example/lib../views/index.html'
    at Error (native)
    at Object.fs.openSync (fs.js:584:18)
    at Object.fs.readFileSync (fs.js:431:33)
    at loadView (/<path>/<to>/<repo>/example/lib/helpers.js:13:13)
```