### PR TITLE
Fixed some vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/dwyl/learn-json-web-tokens",
   "dependencies": {
-    "jsonwebtoken": "^7.0.0",
+    "jsonwebtoken": "^8.3.0",
     "level": "^1.3.0"
   },
   "devDependencies": {
@@ -36,7 +36,7 @@
     "jshint": "^2.8.0",
     "pre-commit": "^1.0.10",
     "request": "^2.60.0",
-    "tap-spec": "^4.0.2",
+    "tap-spec": "^5.0.0",
     "tape": "^4.0.1"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
     "coverage": "istanbul cover ./node_modules/tape/bin/tape ./example/test/functional.js && istanbul check-coverage --statements 100 --functions 100 --lines 100 --branches 100",
     "test": "tape ./example/test/integration.js | tap-spec",
     "start": "node ./example/server.js",
-    "jshint": "jshint -c .jshintrc --exclude-path .gitignore .",
-    "codeclimate": "CODECLIMATE_REPO_TOKEN=38d95ab0f78e69f0c4e1f6c5c8fde7edfcf85d396684eb658b73662154e7b2cc codeclimate ./node_modules/codeclimate-test-reporter/bin/codeclimate.js < ./coverage/lcov.info"
+    "jshint": "jshint -c .jshintrc --exclude-path .gitignore ."
   },
   "repository": {
     "type": "git",
@@ -33,7 +32,6 @@
     "level": "^1.3.0"
   },
   "devDependencies": {
-    "codeclimate-test-reporter": "0.1.0",
     "istanbul": "^0.4.3",
     "jshint": "^2.8.0",
     "pre-commit": "^1.0.10",
@@ -46,7 +44,6 @@
   },
   "pre-commit": [
     "jshint",
-    "coverage",
-    "codeclimate"
+    "coverage"
   ]
 }


### PR DESCRIPTION
I've updated some packages that were flagged as vulnerabilities. I could not get codeclimate up and running and it seems it has not been updated in a while, so I removed it just to be able to push my local changes. Not sure what it was doing, but it blocked my commit because of a pre-commit hook in package.json. 

Also npm outdated returns only one record

Package  Current  Wanted  Latest  Location
level      1.7.0   1.7.0   4.0.0  learn-json-web-tokens
