### PR TITLE
Simplify tinker around with the example

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,6 @@
+ports:
+- port: 1337
+  onOpen: open-preview
+tasks:
+- init: npm install
+  command: node example/server.js

--- a/README.md
+++ b/README.md
@@ -92,6 +92,10 @@ Lets get stuck in with a simple example.
 
 > TRY it: https://jwt.herokuapp.com/
 
+To play around with the example you can open it in Gitpod (requires OAuth with GitHub).
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io#https://github.com/dwyl/learn-json-web-tokens/blob/master/example/lib/helpers.js)
+
 ## Server
 
 Using the *core* **node.js http** server we create 4 endpoints in **/example/server.js**:


### PR DESCRIPTION
This PR adds a gitpod config and button, that allows to open a dev environment for the example in the browser. It will start small container with a shell in the cloud and provide a VS Code based IDE running in the browser. I configured it so it automatically runs  `npm install`  followed by  `npm start`. Also the button will open the helper.js  and the running webapplication in the preview.

Here is a preview of what it would like like:

<img width="1342" alt="screenshot 2019-01-03 at 16 35 32" src="https://user-images.githubusercontent.com/372735/50646164-b4c65d80-0f75-11e9-9620-7e7ed66fde17.png">

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io#snapshot/39fa2e5e-d1ee-4803-8c7e-f222a472d0bb)